### PR TITLE
Support MacPorts installed OpenSSL by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,7 @@ AC_CACHE_CHECK([for OpenSSL directory], ac_cv_openssl_dir, [
   saved_LDFLAGS="$LDFLAGS"
   saved_CPPFLAGS="$CPPFLAGS"
   ssl_found=no
-  for ssldir in $tryssldir "" $prefix /usr/local/openssl /usr/lib/openssl /usr/local/ssl /usr/lib/ssl /usr/local /usr/athena /usr/pkg /opt /opt/openssl ; do
+  for ssldir in $tryssldir "" $prefix /usr/local/openssl /usr/lib/openssl /usr/local/ssl /usr/lib/ssl /usr/local /usr/athena /usr/pkg /opt /opt/local /opt/openssl ; do
     LDFLAGS="$saved_LDFLAGS"
     LIBS="$saved_LIBS -lssl -lcrypto"
 


### PR DESCRIPTION
Should make it so MacPorts users don't need to mess with --with-ssl-dir